### PR TITLE
Add -y flag to confirm on 1 query match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+/.idea/
 /coverage
 /doc/
 .ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.2.1 (Next)
 
+  * Added -y flag to proceed to MFA token if the query has only 1 result
+    -- [@dennisvink][@dennisvink]
 
 ### 0.2.0
 
@@ -20,4 +22,5 @@
   * Add sh command, to open a shell with the environment variables set
     -- [@tader][@tader]
 
+[@dennisvink]: https://github.com/dennisvink/
 [@tader]: https://github.com/tader/

--- a/lib/locksmith-cli/commands/console.rb
+++ b/lib/locksmith-cli/commands/console.rb
@@ -5,7 +5,7 @@ module Locksmith
   module CLI
     class Console < Thor::Group
       def env
-        role = Prompt.for.role(ARGV[1]) # hacky way to obtain query
+        role = Prompt.for.role(ARGV[1], ARGV[2]) # hacky way to obtain query
         exit false if role.nil?
 
         Launchy.open role.signin_url

--- a/lib/locksmith-cli/commands/environment.rb
+++ b/lib/locksmith-cli/commands/environment.rb
@@ -17,7 +17,7 @@ module Locksmith
       }
 
       def env
-        role = Prompt.for.role(ARGV[1]) # hacky way to obtain query
+        role = Prompt.for.role(ARGV[1], ARGV[2]) # hacky way to obtain query
         exit false if role.nil?
 
         ENVIRONMENT_VARIABLES.each do |key, envs|

--- a/lib/locksmith-cli/commands/shell.rb
+++ b/lib/locksmith-cli/commands/shell.rb
@@ -5,7 +5,7 @@ module Locksmith
   module CLI
     class Shell < Thor::Group
       def sh
-        role = Prompt.for.role(ARGV[1]) # hacky way to obtain query
+        role = Prompt.for.role(ARGV[1], ARGV[2]) # hacky way to obtain query
         exit false if role.nil?
 
         env = self.class.clean_environment

--- a/lib/locksmith-cli/support/prompt.rb
+++ b/lib/locksmith-cli/support/prompt.rb
@@ -33,8 +33,8 @@ module Locksmith
       )
     end
 
-    def self.role(query = nil, confirm = nil)
-      bookmark(query, confirm).assume_role(
+    def self.role(query = nil, flag = nil)
+      bookmark(query, flag).assume_role(
         ENV["LS_AWS_ACCESS_KEY_ID"],
         ENV["LS_AWS_SECRET_ACCESS_KEY"],
         ENV["LS_AWS_MFA_SERIAL"]

--- a/lib/locksmith-cli/support/prompt.rb
+++ b/lib/locksmith-cli/support/prompt.rb
@@ -8,7 +8,7 @@ module Locksmith
       self
     end
 
-    def self.bookmark(query=nil)
+    def self.bookmark(query = nil, flag = nil)
       bookmarks = Bookmark.query(
         ENV["LS_API_URL"],
         ENV["LS_API_USER"],
@@ -21,14 +21,20 @@ module Locksmith
         exit false
       end
 
+      if flag == "-y" && bookmarks.count == 1
+        print "Select account "
+        puts "\e[32m#{bookmarks.first()}\e[0m"
+        return bookmarks.first()
+      end
+
       prompt.select(
         "Select account",
         bookmarks
       )
     end
 
-    def self.role(query=nil)
-      bookmark(query).assume_role(
+    def self.role(query = nil, confirm = nil)
+      bookmark(query, confirm).assume_role(
         ENV["LS_AWS_ACCESS_KEY_ID"],
         ENV["LS_AWS_SECRET_ACCESS_KEY"],
         ENV["LS_AWS_MFA_SERIAL"]


### PR DESCRIPTION
This PR enables the -y flag after the query to continue directly to the MFA token input when the query results in a single match.

> $ locksmith sh dennis -y
> Select account Sentia: Dennis Vink
> Enter current MFA code